### PR TITLE
Refactor

### DIFF
--- a/eclib-enum.js
+++ b/eclib-enum.js
@@ -1,4 +1,4 @@
-/** Copyright (c) 2015, Scality
+/* Copyright (c) 2015, Scality
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/eclib-util.js
+++ b/eclib-util.js
@@ -1,4 +1,5 @@
-/** Copyright (c) 2015, Scality * All rights reserved.
+/* Copyright (c) 2015, Scality
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -24,91 +25,44 @@
 
 var enums = require("./eclib-enum.js");
 
-function ECLibUtil() {
-    this.isInt = function(n) {
+module.exports = {
+    getErrorMessage: function(errorcode) {
+        switch (errorcode) {
+            case enums.ErrorCode.EBACKENDNOTSUPP:
+                return "Backend not supported";
+            case enums.ErrorCode.EECMETHODNOTIMPL:
+                return "No method implemented";
+            case enums.ErrorCode.EBACKENDINITERR:
+                return "Backend instance is terminated";
+            case enums.ErrorCode.EBACKENDINUSE:
+                return "Backend instance is in use";
+            case enums.ErrorCode.EBACKENDNOTAVAIL:
+                return "Backend instance not found";
+            case enums.ErrorCode.EBADCHKSUM:
+                return "Fragment integrity check failed";
+            case enums.ErrorCode.EINVALIDPARAMS:
+                return "Invalid arguments";
+            case enums.ErrorCode.EBADHEADER:
+                return "Fragment integrity check failed";
+            case enums.ErrorCode.EINSUFFFRAGS:
+                return "Insufficient number of fragments";
+            default:
+                return "Unknown error";
+        }
+    },
+
+    isInt: function(n) {
         return typeof n === 'number' && n % 1 === 0;
-    }
+    },
+
+    validateInstance: function(opts) {
+        var optArray = Object.keys(opts);
+
+        if (optArray.length !== 6) {
+            return false;
+        }
+        return Object.keys(opts).reduce(function validate(prev, current) {
+            return prev && this.isInt(opts[current]);
+        }.bind(this), true)
+    },
 }
-
-ECLibUtil.prototype.getErrorMessage = function(errorcode) {
-    var errornumber = enums.ErrorCode;
-    var message = null;
-
-    switch (errorcode) {
-        case -errornumber.EBACKENDNOTSUPP:
-            message = "Backend not supported";
-            break;
-
-        case -errornumber.EECMETHODNOTIMPL:
-            message = "No method implemented";
-            break;
-
-        case -errornumber.EBACKENDINITERR:
-            message = "Backend instance is terminated";
-            break;
-
-        case -errornumber.EBACKENDINUSE:
-            message = "Backend instance is in use";
-            break;
-
-        case -errornumber.EBACKENDNOTAVAIL:
-            message = "Backend instance not found";
-            break;
-
-        case -errornumber.EBADCHKSUM:
-            message = "Fragment integrity check failed";
-            break;
-
-        case -errornumber.EINVALIDPARAMS:
-            message = "Invalid arguments";
-            break;
-
-        case -errornumber.EBADHEADER:
-            message = "Fragment integrity check failed";
-            break;
-
-        case -errornumber.EINSUFFFRAGS:
-            message = "Insufficient number of fragments";
-            break;
-
-        default:
-            message = "Unknown error";
-            break;
-    }
-
-    return message;
-};
-
-ECLibUtil.prototype.validateInstanceCreateParams = function(ec_backend_id, k, m,
-    w, hd, ct) {
-
-    var retvalue = true;
-    var argslength = arguments.length;
-
-    retvalue = (argslength === 6);
-
-    while (retvalue && (argslength > 0)) {
-        retvalue = retvalue && this.isInt(arguments[argslength - 1]);
-        argslength--;
-    }
-
-    return retvalue;
-};
-
-ECLibUtil.prototype.validateEncodeParams = function(ec_id, orig_data,
-    deta_length, callback) {
-
-    var retvalue = true;
-    var argslength = arguments.length;
-
-    retvalue = (argslength === 4);
-    retvalue = retvalue && this.isInt(arguments[0]);
-    retvalue = retvalue && this.isInt(arguments[2]);
-    retvalue = retvalue && (orig_data !== undefined) && Buffer.isBuffer(orig_data);
-    // Will check whether the callback is a method or not
-    //retvalue = retvalue && Buffer.isBuffer(orig_data);
-
-    return retvalue;
-};
-
-module.exports = ECLibUtil;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/** Copyright (c) 2015, Scality
+/* Copyright (c) 2015, Scality
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/index.js
+++ b/index.js
@@ -25,4 +25,3 @@
 
 module.exports = require('./node-eclib.js');
 module.exports.enums = require('./eclib-enum.js');
-module.exports.util = require('./eclib-util.js');

--- a/index.js
+++ b/index.js
@@ -24,4 +24,3 @@
  */
 
 module.exports = require('./node-eclib.js');
-module.exports.enums = require('./eclib-enum.js');

--- a/node-eclib.js
+++ b/node-eclib.js
@@ -25,7 +25,7 @@
 
 var addon = require('bindings')('Release/node-eclib.node')
 var util = require("./eclib-util");
-var enums = require("./eclib-enum.js");
+var enums = require("./eclib-enum");
 var __ = require('underscore');
 
 /**
@@ -240,4 +240,5 @@ ECLib.prototype = {
 }
 
 module.exports = ECLib;
+module.exports.enums = enums;
 module.exports.util = util;

--- a/node-eclib.js
+++ b/node-eclib.js
@@ -40,31 +40,18 @@ var __ = require('underscore');
  * @param {Number} [opts.ct=0] - checksum type
  */
 function ECLib(opts) {
-    var d_options = {
-        "bc_id": 0,
-        "k": 8,
-        "m": 4,
-        "w": 0,
-        "hd": 0,
-        "ct": 0
+    this.opt = {
+        bc_id: 0,
+        k: 8,
+        m: 4,
+        w: 0,
+        hd: 0,
+        ct: 0
     };
-
-    this.opt = {};
-    __.extend(this.opt, d_options);
-
-    if (__.size(opts) > 0) {
+    if (opts) {
         __.extend(this.opt, opts);
     }
-
     this.ins_id = null;
-    this.isValidInstance = function() {
-        return (!__.isUndefined(this.ins_id));
-    };
-
-    this.resetOptions = function() {
-        this.opt = null;
-        __.extend(this.opt, d_options);
-    };
 }
 
 ECLib.prototype = {
@@ -111,27 +98,19 @@ ECLib.prototype = {
      * @returns {Number} - Result code
      */
     destroy: function(callback) {
-
-        var resultcode = enums.ErrorCode.EBACKENDNOTAVAIL;
-        var err = {};
-
+        var err = null;
         if (this.isValidInstance()) {
-            resultcode = addon.EclDestroy(this.ins_id);
+            var resultcode = addon.EclDestroy(this.ins_id);
             if (resultcode !== 0) {
-                err.errorcode = resultcode;
-                err.message = util.getErrorMessage(resultcode);
+                err = util.getErrorMessage(resultcode);
             }
         } else {
-            err.errorcode = resultcode;
-            err.message = util.getErrorMessage(resultcode);
+            err = util.getErrorMessage(enums.ErrorCode.EBACKENDNOTAVAIL);
         }
-
         if (!callback) {
-            return resultcode;
+            return err;
         }
-
-        callback.call(this, resultcode, err);
-
+        callback.call(err, this);
     },
 
     /**
@@ -181,7 +160,7 @@ ECLib.prototype = {
      */
     reconstructFragment: function(availFragments, fragmentId, callback) {
         if (!availFragments.length) {
-            callback(new Error('invalid number of available fragments (must be > 0)'), null);
+            callback('invalid number of available fragments (must be > 0)');
             return ;
         }
         addon.EclReconstructFragment(
@@ -234,8 +213,19 @@ ECLib.prototype = {
         // TODO: what is this function supposed to do ?
     },
 
-    setOptions: function(opts){
+    setOptions: function(opts) {
         __.extend(this.opt,opts);
+    },
+
+    resetOptions: function() {
+        this.opt = {
+            bc_id: 0,
+            k: 8,
+            m: 4,
+            w: 0,
+            hd: 0,
+            ct: 0
+        };
     }
 }
 

--- a/node-eclib.js
+++ b/node-eclib.js
@@ -24,7 +24,7 @@
  */
 
 var addon = require('bindings')('Release/node-eclib.node')
-var ECLibUtil = require("./eclib-util.js");
+var util = require("./eclib-util");
 var enums = require("./eclib-enum.js");
 var __ = require('underscore');
 
@@ -57,7 +57,6 @@ function ECLib(opts) {
     }
 
     this.ins_id = null;
-    this.eclibUtil = new ECLibUtil();
     this.isValidInstance = function() {
         return (!__.isUndefined(this.ins_id));
     };
@@ -78,22 +77,20 @@ ECLib.prototype = {
         var instance_descriptor_id = -1;
         var err = {};
         var o = this.opt;
-        if (this.eclibUtil.validateInstanceCreateParams(o.bc_id, o.k,
-                    o.m, o.w, o.hd, o.ct)) {
+        if (util.validateInstance(this.opt)) {
             instance_descriptor_id = addon.EclCreate(o.bc_id, o.k, o.m, o.w,
                     o.hd, o.ct);
 
             if (instance_descriptor_id <= 0) {
                 err.errorcode = instance_descriptor_id;
-                err.message = this.eclibUtil
-                    .getErrorMessage(instance_descriptor_id);
+                err.message = util.getErrorMessage(instance_descriptor_id);
             } else {
                 this.ins_id = instance_descriptor_id;
             }
 
         } else {
             err.errorcode = enums.ErrorCode.EINVALIDPARAMS;
-            err.message = this.eclibUtil.getErrorMessage(err.errorcode);
+            err.message = util.getErrorMessage(err.errorcode);
             instance_descriptor_id = err.errorcode;
         }
 
@@ -102,6 +99,10 @@ ECLib.prototype = {
         }
 
         callback.call(err, this, instance_descriptor_id);
+    },
+
+    isValidInstance: function() {
+        return (!__.isUndefined(this.ins_id));
     },
 
     /**
@@ -118,11 +119,11 @@ ECLib.prototype = {
             resultcode = addon.EclDestroy(this.ins_id);
             if (resultcode !== 0) {
                 err.errorcode = resultcode;
-                err.message = this.eclibUtil.getErrorMessage(resultcode);
+                err.message = util.getErrorMessage(resultcode);
             }
         } else {
             err.errorcode = resultcode;
-            err.message = this.eclibUtil.getErrorMessage(resultcode);
+            err.message = util.getErrorMessage(resultcode);
         }
 
         if (!callback) {
@@ -239,3 +240,4 @@ ECLib.prototype = {
 }
 
 module.exports = ECLib;
+module.exports.util = util;

--- a/test/functional/destroy.js
+++ b/test/functional/destroy.js
@@ -1,71 +1,52 @@
-// test that destroy is OK
-
 'use strict';
 
 var eclib = require('../../index');
-var enums = eclib.enums;
-var ECLibUtil = eclib.util;
-var buffertools = require("buffertools");
+var buffertools = require('buffertools');
 var crypto = require('crypto');
 var assert = require('assert');
 
-function test_one(done) {
+var ref_buf = crypto.randomBytes(100000);
 
+var Eclib = new eclib({
+    bc_id: eclib.enums.BackendId["EC_BACKEND_FLAT_XOR_HD"],
+    k: 3,
+    m: 3,
+    hd: 3
+});
+
+function test_one(done) {
     Eclib.encode(ref_buf, function(status, encoded_data, encoded_parity,
                                    encoded_fragment_length) {
+        var k = Eclib.opt.k;
+        var m = Eclib.opt.m;
 
-    var k = Eclib.opt.k;
-    var m = Eclib.opt.m;
+        var x = k - 1; //available data fragments
+        var y = m; //available parity fragments
 
-    var x = k - 1; //available data fragments
-    var y = m; //available parity fragments
+        var fragments = [];
+        var i, j;
+        j = 0;
+        for (i = 0; i < x; i++) {
+            fragments[j++] = encoded_data[i];
+        }
+        for (i = 0; i < y; i++) {
+            fragments[j++] = encoded_parity[i];
+        }
 
-    var fragments = [];
-    var i, j;
-    j = 0;
-    for (i = 0; i < x; i++) {
-        fragments[j++] = encoded_data[i];
-    }
-    for (i = 0; i < y; i++) {
-        fragments[j++] = encoded_parity[i];
-    }
-
-    Eclib.decode(fragments, 0,
-                 function(status, out_data, out_data_length) {
-
-                     // Buffers must be equal, or else something bad happened.
-                     assert.equal(buffertools.compare(out_data, ref_buf), 0);
-
-                     Eclib.destroy(function(resultcode, err) {
-
-                         assert(resultcode === undefined);
-                         done();
-                     });
-                 });
+        Eclib.decode(fragments, 0, function(status, out_data, out_data_length) {
+            assert.equal(buffertools.compare(out_data, ref_buf), 0);
+            Eclib.destroy(function(err, resultcode) {
+                assert(resultcode === undefined);
+                done();
+            });
+        });
     });
 }
 
-//EC_BACKEND_NULL
-//EC_BACKEND_JERASURE_RS_VAND
-//EC_BACKEND_JERASURE_RS_CAUCHY
-//EC_BACKEND_FLAT_XOR_HD
-//EC_BACKEND_ISA_L_RS_VAND
-//EC_BACKEND_SHSS
-
-var Eclib = new eclib({
-    "bc_id": enums.BackendId["EC_BACKEND_FLAT_XOR_HD"],
-    "k": 3,
-    "m": 3,
-    "hd": 3
-});
-
-var ref_buf = crypto.randomBytes(100000);
-
-describe('DestroyTest', function(done) {
-
+describe('DestroyTest', function assess(done) {
     Eclib.init();
 
-    it('shall destroy nicely', function(done) {
+    it('shall destroy nicely', function destroy(done) {
         test_one(done);
     });
 });

--- a/test/functional/util_valInstance.js
+++ b/test/functional/util_valInstance.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var eclib = require('../../index');
+var enums = eclib.enums;
+var util = eclib.util;
+var assert = require('assert');
+
+var Eclib = new eclib({
+    bc_id: enums.BackendId["EC_BACKEND_JERASURE_RS_VAND"],
+    k: 10,
+    m: 4,
+    w: 16,
+    hd: 5
+});
+
+Eclib.init();
+
+describe('Assess instance validation', function assess(done) {
+    it('should be valid', function shouldValid() {
+        assert(util.validateInstance(Eclib.opt));
+    });
+    it('should be invalid', function shouldInvalid() {
+        assert.equal(util.validateInstance({bc_id: 'tata'}), false);
+    });
+});


### PR DESCRIPTION
Update the API to ensure callbacks are always formatted as `cb(err, something)`. And an overall cleanup, which entails having `eclib.util` as a set of functions rather than a class.