### PR TITLE
Fix checksum type

### DIFF
--- a/src/cpp/libutil.cpp
+++ b/src/cpp/libutil.cpp
@@ -63,11 +63,11 @@ ec_backend_id_t     get_ec_backend_id(int id) {
 
 ec_checksum_type_t  get_ec_checksum_type(int ct) {
     switch(ct) {
-        case 0:
-            return CHKSUM_NONE;
         case 1:
-            return CHKSUM_CRC32;
+            return CHKSUM_NONE;
         case 2:
+            return CHKSUM_CRC32;
+        case 3:
             return CHKSUM_MD5;
         case 99:
             return CHKSUM_TYPES_MAX;

--- a/src/cpp/libutil.cpp
+++ b/src/cpp/libutil.cpp
@@ -41,8 +41,6 @@ ec_args             *el_create_ec_args(int k, int m, int w, int hd,
 
 ec_backend_id_t     get_ec_backend_id(int id) {
     switch(id) {
-        case 0:
-            return EC_BACKEND_NULL;
         case 1:
             return EC_BACKEND_JERASURE_RS_VAND;
         case 2:
@@ -63,8 +61,6 @@ ec_backend_id_t     get_ec_backend_id(int id) {
 
 ec_checksum_type_t  get_ec_checksum_type(int ct) {
     switch(ct) {
-        case 1:
-            return CHKSUM_NONE;
         case 2:
             return CHKSUM_CRC32;
         case 3:


### PR DESCRIPTION
Fix checksum type
Correct values are shown in `eclib-enum.js`:
```
    ChecksumType: {
        "CHKSUM_NONE": 1,
        "CHKSUM_CRC32": 2,
        "CHKSUM_MD5": 3,
        "CHKSUM_TYPES_MAX": 99
    },
```

Updated for checksumType and also backend ID: default value should not be in cases.
 