### PR TITLE
Add cflags to fix failed build in clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ $(ERASUREPATH)/Makefile: | $(ERASUREPATH)
 	cd $(ERASUREPATH) && ./autogen.sh && ./configure --prefix=$(LIBDIR)
 
 $(ERASURELIB): | $(ERASUREPATH)/Makefile
-	$(MAKE) -C $(ERASUREPATH) && $(MAKE) -C $(ERASUREPATH) install
+	$(MAKE) CFLAGS=-Wno-error -C $(ERASUREPATH) \
+		&& $(MAKE) -C $(ERASUREPATH) install
 
 clean:
 	$(RM) $(TARGET)


### PR DESCRIPTION
An error occurs for compiling in clang (mac os):

```
erasurecode.c:1090:17: error: comparison of unsigned expression < 0
is always false [-Werror,-Wtautological-compare]
```

A temporary fix is adding a cflags in makefile.
