### PR TITLE
FIX: Reconstruct multiple fragments

### DIFF
--- a/node-eclib.js
+++ b/node-eclib.js
@@ -191,17 +191,29 @@ ECLib.prototype = {
         // the 6th fragment.
         var done = 0;
 
-        fragmentIds.sort();
-
+        fragmentIds.sort(function(a, b) {
+            return (a - b);
+        });
+        var len = fragmentIds.length;
+        var recFrags = new Array(len);
+        var error;
         // Recover all missing fragments one by one.
-        fragmentIds.forEach(function reconstructEach(id) {
+        fragmentIds.forEach(function reconstructEach(id, index) {
             this.reconstructFragment(availFragments, id,
                     function recon(err, fragment) {
                         if (err) {
-                            callback(err);
+                            error = err;
+                            return;
                         }
-                        availFragments.splice(id, 0, fragment);
-                        if (++done === fragmentIds.length) {
+                        recFrags[index] = fragment;
+                        if (++done === len) {
+                            if (error) {
+                                callback(error);
+                                return;
+                            }
+                            fragmentIds.forEach(function(fragIdx, idx) {
+                                availFragments.splice(fragIdx, 0, recFrags[idx]);
+                            });
                             callback(null, availFragments);
                             return ;
                         }

--- a/test/functional/reconstruct_mult.js
+++ b/test/functional/reconstruct_mult.js
@@ -16,7 +16,8 @@ var ec = new eclib({
 
 ec.init();
 
-var data = new Buffer("Hello world of Rust ! This is some serious decoding !");
+var dataSize = 1024 * 1024;
+var data = crypto.randomBytes(dataSize);
 
 describe('reconstruct multiple fragments:', function(done) {
 
@@ -28,8 +29,10 @@ ec.encode(data, function(status, dataFragments, parityFragments, fragmentLength)
     // Lose 3 fragments, 2 of which are data. We should be able to still
     // recover the data.
     var missing_frags_indx = [1, 0, 5];
-    // descending ordered
-    missing_frags_indx.sort();
+    // decreasing ordered
+    missing_frags_indx.sort(function(a, b){
+        return (b - a);
+    });
     // backup missing fragments
     var orig_missing_frags = [allFragments[missing_frags_indx[0]]];
     for (var idx = 1; idx < missing_frags_indx.length; idx++){


### PR DESCRIPTION
Fragments reconstruction runs in parallel. Hence recovered fragments
could be not in right order.

Fix sort function